### PR TITLE
switch to new output command

### DIFF
--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -26,9 +26,9 @@ jobs:
         # c:\\conda-bld seems to work.... for now
         run: |
           if [ ${{ matrix.os }} = windows-latest ]; then
-            echo "::set-output name=condabld::c:\\conda-bld"
+            echo "condabld=c:\\conda-bld" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=condabld::$HOME/conda-bld"
+            echo "condabld=$HOME/conda-bld" >> $GITHUB_OUTPUT
           fi
         shell: bash
 


### PR DESCRIPTION
Check that the build is green
Background https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 