### PR TITLE
Build review

### DIFF
--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install conda build
-        run: conda install -y -q conda-build conda-verify
+        run: conda install -y -q "conda-build<25.0.0" conda-verify
 
       - name: Build bftools-libs
         run: conda build bftools-libs

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, ubuntu-22.04, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
       - name: setup-conda

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install conda build
-        run: conda install -y -q "conda-build<25.1.0" conda-verify
+        run: conda install -y -q conda-build conda-verify
 
       - name: Build bftools-libs
-        run: conda build bftools-libs
+        run: conda build bftools-libs --package-format tar.bz2
         shell: bash -el {0}
       - name: Build bftools
-        run: conda build bftools
+        run: conda build bftools --package-format tar.bz2
         shell: bash -el {0}
       
       - run: ls -R "${{ steps.condablddir.outputs.condabld }}"

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install conda build
-        run: conda install -y -q "conda-build<25.0.0" conda-verify
+        run: conda install -y -q "conda-build<25.1.0" conda-verify
 
       - name: Build bftools-libs
         run: conda build bftools-libs

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-14, ubuntu-latest, windows-latest]
+        os: [macos-14, ubuntu-22.04, windows-latest]
       fail-fast: false
     steps:
       - name: setup-conda


### PR DESCRIPTION
* macos-12 has now been removed
* newest version of ``conda-build`` prevents the build to pass. This is fixed using ```--package-format tar.bz2``` parameter. This default is now ``.conda`` since version 25.1.0